### PR TITLE
DOM Events can be removed with `null`

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -15,7 +15,7 @@ export type DomAttrs = {
   style: Partial<Properties> | string;
   role: "button" | "list" | "listbox";
   events: Partial<{
-    [K in keyof HTMLElementEventMap]: EventHandler;
+    [K in keyof HTMLElementEventMap]: EventHandler | null;
   }>;
 };
 
@@ -86,10 +86,12 @@ export function update(
 
   Object.entries(events as NonNullable<typeof attrs.events>).forEach(
     ([k, v]) => {
-      if (v === null && $events.has(k)) {
-        const listener = $events.get(k)!;
-        element.removeEventListener(k, listener);
-      } else if (!$events.has(k)) {
+      if (v === null) {
+        if ($events.has(k)) {
+          const listener = $events.get(k)!;
+          element.removeEventListener(k, listener);
+        }
+      } else if (v !== undefined) {
         element.addEventListener(k as keyof ElementEventMap, v);
         $events.set(k, v);
       }

--- a/src/dom/html.test.ts
+++ b/src/dom/html.test.ts
@@ -16,16 +16,16 @@ describe("html", () => {
   });
 
   it("attaches event handlers", () => {
-    let clicked = false;
+    let clicked = 0;
     const btn = button({
       events: {
         click: () => {
-          clicked = true;
+          clicked += 1;
         },
       },
     });
     btn.dispatchEvent(new Event("click"));
-    expect(clicked).toBe(true);
+    expect(clicked).toBe(1);
   });
 
   it("removes event handlers", () => {
@@ -41,7 +41,7 @@ describe("html", () => {
 
     expect(clicked).toBe(1);
 
-    btn.update({ events: { click: undefined } });
+    btn.update({ events: { click: null } });
     btn.dispatchEvent(new Event("click"));
     expect(clicked).toBe(1);
   });


### PR DESCRIPTION
`undefined` when updating a DOM event block means "no change"