### PR TITLE
Load JSDom when running as Node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davidsouther/jiffies",
-  "version": "2026.4.0",
+  "version": "2026.4.1",
   "private": false,
   "displayName": "JEFRi Jiffies",
   "type": "module",
@@ -29,9 +29,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
+    "@types/jsdom": "^27.0.0",
     "@types/node": "^20.8.9"
   },
   "dependencies": {
+    "jsdom": "^27.4.0",
     "ts-blank-space": "^0.7.0",
     "typescript": "^5.9.3"
   }

--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -35,7 +35,7 @@ export const Input(name, type="string") => {
     )
 }
 
-document.body.append(
+window.document.body.append(
     Form(
         {
             title: "Details",

--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -1,6 +1,13 @@
 import { assertExists } from "../assert.ts";
 import type { Properties as SVGProperties } from "./types/css.ts";
 
+if (typeof window === "undefined") {
+  const { JSDOM } = await import("jsdom");
+  // biome-ignore lint/suspicious/noGlobalAssign: Load JSDom globally
+  window = global.window = new JSDOM().window as unknown as Window &
+    typeof globalThis;
+}
+
 export const XHTML_NAMESPACE_URI = "http://www.w3.org/1999/xhtml";
 export const SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg";
 

--- a/src/dom/fc.ts
+++ b/src/dom/fc.ts
@@ -68,7 +68,10 @@ export function FC<Props extends object, State extends object = object>(
     attrs?: Attrs<Props> | DenormChildren,
     ...children: DenormChildren[]
   ): FCComponent<Props, State> => {
-    const element = document.createElement(name) as FCComponent<Props, State>;
+    const element = window.document.createElement(name) as FCComponent<
+      Props,
+      State
+    >;
     element.update(attrs, ...children);
     return element;
   };

--- a/src/dom/html.ts
+++ b/src/dom/html.ts
@@ -7,7 +7,7 @@ const makeHTMLElement =
     ...children: DenormChildren[]
   ) =>
     up(
-      document.createElement(name),
+      window.document.createElement(name),
       attrs,
       ...children,
     ) as HTMLElementTagNameMap[K];

--- a/src/dom/router/router.ts
+++ b/src/dom/router/router.ts
@@ -7,7 +7,7 @@ export interface Router {
   (target: DOMElement): DOMElement;
 }
 
-const baseURI = `${document.baseURI}`;
+const baseURI = `${window.document.baseURI}`;
 const normalizeHref = () => {
   return `${location.href}/` === baseURI ? baseURI : location.href;
 };


### PR DESCRIPTION
Browser/Vite still uses the browser window when available.