### PR TITLE
Drop dead loader.mjs references

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,29 +3,12 @@
   "configurations": [
     {
       "type": "node",
-      "nodeVersionHint": 16,
+      "nodeVersionHint": 22,
       "request": "launch",
       "name": "Server",
       "skipFiles": ["<node_internals>/**"],
-      "runtimeArgs": [
-        "--experimental-loader",
-        "${workspaceFolder}/src/loader.mjs"
-      ],
       "program": "${workspaceFolder}/src/server/main.ts",
-      "args": ["--port=8080"],
-      // TODO(fix)
-      "runtimeExecutable": "/usr/local/bin/node"
-    },
-    {
-      "name": "Debug CRA Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "${workspaceFolder}/computron5k/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
-      "cwd": "${workspaceFolder}",
-      "protocol": "inspector",
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "args": ["--port=8080"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ JEFRi Jiffies are a number of "common" utilities for JavaScript/TypeScript pulle
 - `flags` - JavaScript flag, environment, and configuration loader.
 - `log` - JavaScript implementation of a [log4j][log4j]-alike logger.
 - `result` - JavaScript implementation of Rust's [Option][rustoption] and [Result][rustresult] types.
-- `loader.mjs` - Node 16.x typescript-transpiling module loader.
 
 Jiffies also includes several microframeworks.
 

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-loader ../loader.mjs
+#!/usr/bin/env node
 import * as process from "node:process";
 
 import { info } from "../log.ts";


### PR DESCRIPTION
`src/loader.mjs` no longer exists; native Node type-stripping (`>=22.18.0`) carries the project. This removes the last references to it.

- **README**: drop the `loader.mjs` bullet (and its Node 16.x framing).
- **`src/server/main.ts`**: strip `--experimental-loader ../loader.mjs` from the shebang → `#!/usr/bin/env node`.
- **`.vscode/launch.json`**: remove the `--experimental-loader` runtimeArgs from the "Server" config, bump `nodeVersionHint` 16→22, drop the dead `/usr/local/bin/node` runtimeExecutable (the `TODO(fix)`), and remove the dead "Debug CRA Tests" config (pointed at the absent `computron5k` tree).

## Verification
- `npm test` → 40/40.
- `npm start` and direct shebang execution both boot and listen.
- `biome check` clean on changed files; `launch.json` valid JSONC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)