### PR TITLE
feat(dom): add FCC containerless components for SVG

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -292,6 +292,58 @@ function findUnclaimedNodes(
   return { mountedSet, unclaimed };
 }
 
+/**
+ * A unit boundary the reconcile, hydration, and SSG passes treat as opaque: a
+ * registered custom element (FC), or any element carrying `data-fc` (FCC). Both
+ * own their own subtree, so a parent's reconcile must not descend into them.
+ */
+export function isUnit(el: Element): boolean {
+  return customElements.get(el.localName) != null || el.hasAttribute("data-fc");
+}
+
+/**
+ * Walk `root` depth-first and return every unit (`isUnit`) in document order,
+ * descending INTO units so nested units are included. The server payload build
+ * and the client hydration scan must enumerate units in the same order, or a
+ * payload index will not line up.
+ */
+export function scanAllUnits(root: ParentNode): Element[] {
+  const results: Element[] = [];
+  const stack: Element[] = [...root.children].reverse() as Element[];
+  while (stack.length > 0) {
+    const el = stack.pop() as Element;
+    if (isUnit(el)) {
+      results.push(el);
+    }
+    for (let i = el.children.length - 1; i >= 0; i--) {
+      stack.push(el.children[i] as Element);
+    }
+  }
+  return results;
+}
+
+/** True if `el` has a unit ancestor (i.e. it is a nested unit). */
+export function isNested(el: Element, units: Element[]): boolean {
+  let parent = el.parentElement;
+  while (parent !== null) {
+    if (units.includes(parent)) return true;
+    parent = parent.parentElement;
+  }
+  return false;
+}
+
+/**
+ * Reconstruct a unit's props from its attributes, skipping the `data-fc` marker.
+ */
+export function propsFromElement(el: Element): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  for (const attr of el.attributes) {
+    if (attr.name === "data-fc") continue;
+    props[attr.name] = attr.value;
+  }
+  return props;
+}
+
 export function patchNode(kept: Element, fresh: Element): void {
   assert(kept.nodeName === fresh.nodeName, "patching nodes of different types");
 
@@ -320,8 +372,8 @@ export function patchNode(kept: Element, fresh: Element): void {
     setListener(kept, keptEvents, type, handler);
   }
 
-  // Custom elements rebuild their own subtrees
-  if (customElements.get(kept.localName)) return;
+  // Unit boundaries rebuild their own subtrees
+  if (isUnit(kept)) return;
 
   reconcileChildren(kept, Array.from(fresh.childNodes));
 }

--- a/src/dom/fc.ts
+++ b/src/dom/fc.ts
@@ -10,6 +10,10 @@ import {
 export type Attrs<S> = S & Partial<DomAttrs>;
 
 export const State = Symbol();
+
+// Per-instance update inputs
+const Inputs = Symbol();
+
 export interface FCComponent<Props extends object, State extends object>
   extends Element {
   [State]?: Partial<State>;
@@ -29,52 +33,164 @@ export type FCComponentCtor<Props extends object, State extends object> = (
   ...children: DenormChildren[]
 ) => FCComponent<Props, State>;
 
+interface WithInputs<Props extends object, S extends object>
+  extends FCComponent<Props, S> {
+  [Inputs]?: { attrs: Attrs<Props>; children: DenormChildren[] };
+}
+
+/**
+ * Update a Functional Component.
+ * Merges this call and element's current attrs, apply them onto the element, re-runs
+ * `render`, and reconciles that output with the element's children. All per-instance
+ * state ([State] and the inputs stash) lives on `el`, so a single `update`
+ * function serves every instance.
+ *
+ * The `render` callback returns children, not the element, as the element factory
+ * builds the parent.
+ */
+export function applyUpdate<Props extends object, S extends object>(
+  el: FCComponent<Props, S>,
+  render: RenderFn<Props, S>,
+  attrs?: Attrs<Props> | DenormChildren,
+  children: DenormChildren[] = [],
+): void {
+  [attrs, children] = normalizeArguments(attrs, children) as [
+    Attrs<Props>,
+    DenormChildren[],
+  ];
+  const unit = el as WithInputs<Props, S>;
+  unit[State] ??= {};
+  unit[Inputs] ??= { attrs: {} as Attrs<Props>, children: [] };
+  const inputs = unit[Inputs];
+  if (children[0] === CLEAR) {
+    inputs.children = [];
+  } else if (children.length > 0) {
+    inputs.children = children;
+  }
+  inputs.attrs = { ...inputs.attrs, ...(attrs as Attrs<Props>) };
+
+  // Apply attrs to the element itself (no children here), then re-run the
+  // component and reconcile its return value as the element's children.
+  update(el, inputs.attrs, []);
+  const rendered = [render(el, inputs.attrs, inputs.children)];
+  reconcileChildren(el, rendered.flat());
+}
+
+/**
+ * A Functional Component backed by a custom element.
+ */
 export function FC<Props extends object, State extends object = object>(
   name: string,
   component: RenderFn<Props, State>,
 ): FCComponentCtor<Props, State> {
-  class FCImpl extends HTMLElement implements FCComponent<Props, State> {
-    [State]: Partial<State> = {};
-    #attrs: Attrs<Props> = {} as Attrs<Props>;
-    #children: DenormChildren[] = [];
-
-    update(
-      attrs?: Attrs<Props> | DenormChildren,
-      ...children: DenormChildren[]
-    ) {
-      [attrs, children] = normalizeArguments(attrs, children) as [
-        Attrs<Props>,
-        DenormChildren[],
-      ];
-      if (children[0] === CLEAR) {
-        this.#children = [];
-      } else if (children.length > 0) {
-        this.#children = children;
+  customElements.define(
+    name,
+    // The shared `update` is carried on the prototype, not attached per
+    // instance, so a server-rendered element upgraded by the platform during
+    // hydration gains `update()` without the FCC constructor running.
+    class extends HTMLElement implements FCComponent<Props, State> {
+      [State]: Partial<State> = {};
+      update(
+        attrs?: Attrs<Props> | DenormChildren,
+        ...children: DenormChildren[]
+      ): this {
+        applyUpdate(this, component, attrs, children);
+        return this;
       }
-      this.#attrs = { ...this.#attrs, ...(attrs as Attrs<Props>) };
+    },
+  );
 
-      // Apply updates from the attrs to the dom node itself
-      update(this, this.#attrs, []);
+  return FCC(name, () => window.document.createElement(name), component, true);
+}
 
-      // Re-run the component function using new element, attrs, and children.
-      const rendered = [component(this, this.#attrs, this.#children)];
-      reconcileChildren(this, rendered.flat());
-      return this;
-    }
-  }
+/** Factory that builds an FC root in the correct namespace. */
+export type BoundaryFactory = () => Element;
 
-  customElements.define(name, FCImpl);
+/** The shared, per-definition update each FCC element carries. */
+type UpdateFn = FCComponent<object, object>["update"];
 
-  const ctor: FCComponentCtor<Props, State> = (
+// Module-level name -> update-function registry. Backs FCC where
+// `customElements` backs FC: it lets a server-rendered `data-fc` element be
+// re-wired during hydration with the same shared `update` its live instances
+// use, when there is no custom-element upgrade to do it.
+const registry = new Map<string, UpdateFn>();
+
+/** Look up the shared `update` registered for a `data-fc` name, if any. */
+export function getFCC(name: string): UpdateFn | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Wire an FCC's shared `update` onto a real element. The element carries its own
+ * `[State]` and inputs (set lazily on the first `update()` call), so this only
+ * assigns the single definition-wide function. Shared by the FCC constructor and
+ * the hydration path, which passes the registry-resolved `update`.
+ */
+export function attach<Props extends object, S extends object>(
+  el: Element,
+  update: FCComponent<Props, S>["update"],
+): FCComponent<Props, S> {
+  const component = el as FCComponent<Props, S>;
+  component.update = update;
+  return component;
+}
+
+/**
+ * A containerless component (FCC) renders directly without an HTML custom-element
+ * host. Its boundary is a single real element (SVG or HTML) marked `data-fc`, so
+ * a component can render SVG-namespace shapes inside `<svg>`, where an HTML custom
+ * element is not valid content.
+ *
+ * FCC shares the `name` and `render` parameters with FC, and additionally takes a
+ * boundary factory that returns the FCC's root element. Attributes passed to an FCC
+ * will be set on this element. `render` returns the children of the FCC boundary
+ * root.
+ *
+ * The returned constructor builds the boundary, marks it, wires the shared
+ * `update()` onto it, and returns the element to include directly:
+ *
+ * ```ts
+ * const Gauge = FCC<{ value: number }>("gauge", g, (_el, attrs) => [
+ *   circle({ r: 10 }),
+ *   circle({ class: "needle", r: 2, cx: attrs.value }),
+ * ]);
+ * svg({ viewBox: "0 0 100 100" }, Gauge({ value: 5 }));
+ * // → <svg ...><g data-fc="gauge"><circle r="10"/><circle class="needle" r="2" cx="5"/></g></svg>
+ * ```
+ */
+export function FCC<Props extends object, S extends object = object>(
+  name: string,
+  boundary: BoundaryFactory,
+  render: RenderFn<Props, S>,
+  _isCustom = false,
+): FCComponentCtor<Props, S> {
+  function update(
+    this: FCComponent<Props, S>,
     attrs?: Attrs<Props> | DenormChildren,
     ...children: DenormChildren[]
-  ): FCComponent<Props, State> => {
-    const element = window.document.createElement(name) as FCComponent<
-      Props,
-      State
-    >;
-    element.update(attrs, ...children);
-    return element;
+  ): FCComponent<Props, S> {
+    applyUpdate(this, render, attrs, children);
+    return this;
+  }
+
+  if (!_isCustom) {
+    registry.set(name, update as unknown as UpdateFn);
+  }
+
+  const ctor: FCComponentCtor<Props, S> = (
+    attrs?: Attrs<Props> | DenormChildren,
+    ...children: DenormChildren[]
+  ): FCComponent<Props, S> => {
+    const element = boundary();
+    let component: FCComponent<Props, S>;
+    if (_isCustom) {
+      component = element as FCComponent<Props, S>;
+    } else {
+      element.setAttribute("data-fc", name);
+      component = attach<Props, S>(element, update);
+    }
+    component.update(attrs, ...children);
+    return component;
   };
 
   return ctor;

--- a/src/dom/fcc.test.ts
+++ b/src/dom/fcc.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  reconcileChildren,
+  SVG_NAMESPACE_URI,
+  XHTML_NAMESPACE_URI,
+} from "./dom.ts";
+import { FCC } from "./fc.ts";
+import { div, h2, p, section } from "./html.ts";
+import { buildPayload, start } from "./hydrate.ts";
+import { circle, g, svg } from "./svg.ts";
+
+// A containerless SVG component. Its boundary is a real <g> marked data-fc, and
+// the render callback returns children (the FC-mirror contract). The callback
+// allocates fresh circles on every call, sharing no node references between
+// renders. That is the shape that defeats an identity-only reconcile at the
+// boundary.
+const Gauge = FCC<{ value: number }>("gauge", g, (_el, attrs) => [
+  circle({ r: 10 }),
+  circle({ class: "needle", r: 2, cx: attrs.value }),
+]);
+
+describe("FCC containerless SVG component", () => {
+  it("renders SVG nodes directly into <svg> with no HTML host, and reuses nodes across re-render", () => {
+    // Arrange + Act: build the component and place it directly inside an <svg>.
+    const gauge = Gauge({ value: 5 });
+    const root = svg({ viewBox: "0 0 100 100" }, gauge);
+    window.document.body.append(root);
+
+    // The boundary is a real SVG element marked data-fc, sitting directly in the
+    // <svg>. No HTML custom element wraps it.
+    assert.strictEqual(
+      gauge.namespaceURI,
+      SVG_NAMESPACE_URI,
+      "the boundary is in the SVG namespace",
+    );
+    assert.strictEqual(
+      gauge.localName,
+      "g",
+      "the boundary is a real <g>, not an HTML custom element host",
+    );
+    assert.strictEqual(gauge.getAttribute("data-fc"), "gauge");
+    assert.strictEqual(
+      gauge.parentNode,
+      root,
+      "the boundary renders directly inside the <svg>",
+    );
+
+    // Its children are real SVG-namespace nodes.
+    const needle1 = gauge.querySelector(".needle");
+    assert.ok(needle1, "the component rendered the needle");
+    assert.strictEqual(
+      needle1.namespaceURI,
+      SVG_NAMESPACE_URI,
+      "the child circle is in the SVG namespace",
+    );
+    assert.strictEqual(needle1.getAttribute("cx"), "5");
+
+    // Act: re-render with new attrs. Same logical tree, freshly allocated nodes.
+    gauge.update({ value: 42 });
+
+    // Assert: the nested node is the SAME node, its attribute patched in place.
+    // Identity survived the re-render through the marked boundary.
+    const needle2 = gauge.querySelector(".needle");
+    assert.strictEqual(
+      needle2,
+      needle1,
+      "the needle node is reused, not rebuilt",
+    );
+    assert.strictEqual(
+      needle2?.getAttribute("cx"),
+      "42",
+      "the reused node reflects the new attr",
+    );
+  });
+
+  it("hydrates a server-rendered marked boundary through start()", (t) => {
+    // Arrange — SERVER: an inert, parsed <g data-fc="gauge"> with a stale child
+    // and no wired update() (the platform never upgrades a data-fc element). A
+    // payload carries the unit's props by document-order index.
+    const script = window.document.createElement("script");
+    script.type = "application/json";
+    script.id = "__hydration";
+    script.textContent = buildPayload([{ value: 7 }]);
+    window.document.head.appendChild(script);
+
+    const boundary = window.document.createElementNS(SVG_NAMESPACE_URI, "g");
+    boundary.setAttribute("data-fc", "gauge");
+    boundary.appendChild(
+      window.document.createElementNS(SVG_NAMESPACE_URI, "circle"),
+    );
+    const root = svg({ viewBox: "0 0 100 100" });
+    root.appendChild(boundary);
+    // A dedicated container isolates this scan from any DOM other cases left in
+    // the body.
+    const container = window.document.createElement("div");
+    container.appendChild(root);
+    window.document.body.append(container);
+    t.after(() => {
+      script.remove();
+      container.remove();
+    });
+
+    // Act — start() finds the data-fc unit, re-wires update()/[State] from the
+    // registry (the top-level FCC("gauge", ...) call populated it), and
+    // re-renders it against its indexed payload. The data-fc path is synchronous.
+    start(container);
+
+    // Assert — the SAME server boundary node was adopted, and its children were
+    // rebuilt from the payload props.
+    assert.strictEqual(
+      container.querySelector("[data-fc='gauge']"),
+      boundary,
+      "start() adopted the server boundary; it did not replace it",
+    );
+    const needle = boundary.querySelector(".needle");
+    assert.ok(needle, "the boundary rebuilt its children on hydration");
+    assert.strictEqual(
+      needle.getAttribute("cx"),
+      "7",
+      "the rebuilt child reflects the payload props",
+    );
+  });
+});
+
+// A containerless HTML component. Its boundary is a real <div> marked data-fc,
+// host-free: <div> is not a registered custom element, so the marker is the only
+// thing that makes the boundary a unit. The render callback allocates fresh HTML
+// children on every call, sharing no node references between renders.
+const Card = FCC<{ title: string }>("card", div, (_el, attrs) => [
+  h2({ class: "title" }, attrs.title),
+  p({ class: "body" }, "static body"),
+]);
+
+describe("FCC containerless HTML component", () => {
+  it("renders HTML directly into a parent with no custom-element host, and reuses nodes across re-render", () => {
+    // Arrange + Act: build the component and place it directly inside a <section>.
+    const card = Card({ title: "Hello" });
+    const root = section(card);
+    window.document.body.append(root);
+
+    // The boundary is a real <div> in the HTML namespace, marked data-fc, sitting
+    // directly in the <section>. It is host-free: <div> is not a registered
+    // custom element, so nothing wraps the unit but the marker.
+    assert.strictEqual(
+      card.namespaceURI,
+      XHTML_NAMESPACE_URI,
+      "the boundary is in the HTML namespace",
+    );
+    assert.strictEqual(card.localName, "div", "the boundary is a real <div>");
+    assert.strictEqual(
+      customElements.get("div"),
+      undefined,
+      "the boundary is not a registered custom element; data-fc is the only marker",
+    );
+    assert.strictEqual(card.getAttribute("data-fc"), "card");
+    assert.strictEqual(
+      card.parentNode,
+      root,
+      "the boundary renders directly inside the <section>",
+    );
+
+    // Its children are real HTML-namespace nodes.
+    const title1 = card.querySelector(".title");
+    assert.ok(title1, "the component rendered the title");
+    assert.strictEqual(
+      title1.namespaceURI,
+      XHTML_NAMESPACE_URI,
+      "the child is in the HTML namespace",
+    );
+    assert.strictEqual(title1.textContent, "Hello");
+
+    // Act: re-render with new attrs. Same logical tree, freshly allocated nodes.
+    card.update({ title: "Goodbye" });
+
+    // Assert: the nested node is the SAME node, its content patched in place.
+    // Identity survived the re-render through the marked boundary.
+    const title2 = card.querySelector(".title");
+    assert.strictEqual(title2, title1, "the title node is reused, not rebuilt");
+    assert.strictEqual(
+      title2?.textContent,
+      "Goodbye",
+      "the reused node reflects the new attr",
+    );
+  });
+
+  it("stays opaque when its HTML parent reconciles", () => {
+    // Arrange: the FCC <div> lives inside a parent. For HTML, the boundary is an
+    // ordinary <div> to the reconciler; only data-fc marks it as a unit.
+    const card = Card({ title: "Kept" });
+    const parent = div(card);
+    window.document.body.append(parent);
+    const title = card.querySelector(".title");
+    assert.ok(title, "precondition: the card rendered its title");
+
+    // Act: reconcile the parent against a BRAND NEW <div data-fc="card"> carrying
+    // a different title. Same nodeName, so the kept boundary is patched in place
+    // rather than replaced. Without the marker, the parent's reconcile would
+    // descend and rebuild the card's subtree from freshCard's children.
+    const freshCard = Card({ title: "Injected", class: "patched" });
+    reconcileChildren(parent, [freshCard]);
+
+    // Assert: the original boundary survived (adopted, not replaced), its own
+    // attrs were patched, but the reconcile did NOT descend — the nested node
+    // identity is intact and freshCard's "Injected" title was never adopted.
+    assert.strictEqual(
+      parent.querySelector("[data-fc='card']"),
+      card,
+      "the parent kept the original boundary; it did not swap in freshCard",
+    );
+    assert.strictEqual(
+      card.getAttribute("class"),
+      "patched",
+      "the boundary's own attrs were patched by the parent reconcile",
+    );
+    assert.strictEqual(
+      card.querySelector(".title"),
+      title,
+      "the nested node identity survived; the parent reconcile stayed out of the unit",
+    );
+    assert.strictEqual(
+      title.textContent,
+      "Kept",
+      "the unit kept its own children; freshCard's title was not adopted",
+    );
+  });
+
+  it("hydrates a server-rendered marked HTML boundary through start()", (t) => {
+    // Arrange — SERVER: an inert, parsed <div data-fc="card"> with a stale child
+    // and no wired update() (the platform never upgrades a data-fc element). A
+    // payload carries the unit's props by document-order index.
+    const script = window.document.createElement("script");
+    script.type = "application/json";
+    script.id = "__hydration";
+    script.textContent = buildPayload([{ title: "Server" }]);
+    window.document.head.appendChild(script);
+
+    const boundary = window.document.createElement("div");
+    boundary.setAttribute("data-fc", "card");
+    boundary.appendChild(window.document.createElement("span"));
+    // A dedicated container isolates this scan from any DOM the other cases left
+    // in the body.
+    const container = window.document.createElement("div");
+    container.appendChild(boundary);
+    window.document.body.append(container);
+    t.after(() => {
+      script.remove();
+      container.remove();
+    });
+
+    // Act — start() finds the data-fc unit, re-wires update()/[State] from the
+    // registry (the top-level FCC("card", ...) call populated it), and re-renders
+    // it against its indexed payload. The data-fc path is synchronous.
+    start(container);
+
+    // Assert — the SAME server boundary node was adopted, and its children were
+    // rebuilt from the payload props.
+    assert.strictEqual(
+      container.querySelector("[data-fc='card']"),
+      boundary,
+      "start() adopted the server boundary; it did not replace it",
+    );
+    const title = boundary.querySelector(".title");
+    assert.ok(title, "the boundary rebuilt its children on hydration");
+    assert.strictEqual(
+      title.textContent,
+      "Server",
+      "the rebuilt child reflects the payload props",
+    );
+  });
+});

--- a/src/dom/hydrate.test.ts
+++ b/src/dom/hydrate.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { FileSystem, RecordFileSystemAdapter } from "../fs.ts";
 import { build, type PageModule } from "../ssg/ssg.ts";
-import { FC, type FCComponent, State } from "./fc.ts";
-import { button, div, form, input } from "./html.ts";
+import { FC, FCC, type FCComponent, State } from "./fc.ts";
+import { button, div, form, input, span } from "./html.ts";
 import {
   buildPayload,
   hydrateRoot,
@@ -169,6 +169,20 @@ const Greeter = FC<GreetProps>("hydrate-greeter", (_el, attrs) => {
   return div(text);
 });
 void Greeter;
+
+// An FCC (host-free, `data-fc` boundary) whose child echoes a prop. Used to test
+// that hydration carries props to both component forms, and as a nested unit.
+const Badge = FCC<{ label: string }>("hydrate-badge", div, (_el, attrs) =>
+  span(`[${attrs.label ?? "?"}]`),
+);
+void Badge;
+
+// An FC containing a Badge: the Badge is a NESTED unit, so the server payload
+// lists it between two top-level units in document order.
+const Panel = FC<{ who: string }>("hydrate-panel", (_el, attrs) =>
+  div(Badge({ label: attrs.who ?? "?" })),
+);
+void Panel;
 
 describe("hydrate — M2: hydrateRoot whole-app reconcile", () => {
   it("reconciles without detaching the shell: a focused input's node identity survives", (t) => {
@@ -729,6 +743,92 @@ describe("hydrate — M5: build integration", () => {
     assert.ok(
       html.includes(clientEntry),
       "the client entry path must appear in the module script",
+    );
+  });
+});
+
+describe("hydrate — M6: props survive hydration", () => {
+  it("hydrateRoot re-renders an FC with its server attributes as props", async (t) => {
+    // Arrange — SERVER: an FC with props baked into its attributes and a stale
+    // child. hydrateRoot does not read the #__hydration payload; the only source
+    // of props for a kept server unit is the attributes the reconcile pass syncs
+    // onto it from the freshly rendered tree.
+    window.document.body.innerHTML = `<hydrate-greeter name="Ada" count="3"><div>stale</div></hydrate-greeter>`;
+    t.after(() => {
+      window.document.body.innerHTML = "";
+    });
+
+    // Act — reconcile the same render onto the live shell, then hydrate.
+    hydrateRoot(window.document.body, () => [
+      Greeter({ name: "Ada", count: 3 }),
+    ]);
+    await tick();
+
+    // Assert — the re-render saw the props, not an empty object.
+    const fc = window.document.body.querySelector("hydrate-greeter");
+    assert.equal(
+      fc?.textContent,
+      "Hello Ada x3",
+      "hydrateRoot passed the server attributes to the FC's update()",
+    );
+  });
+
+  it("hydrateRoot carries props into a host-free FCC boundary", async (t) => {
+    // Arrange — a server-rendered FCC <div data-fc> with its prop in an attribute.
+    window.document.body.innerHTML = `<div data-fc="hydrate-badge" label="Live"><span>stale</span></div>`;
+    t.after(() => {
+      window.document.body.innerHTML = "";
+    });
+
+    // Act
+    hydrateRoot(window.document.body, () => [Badge({ label: "Live" })]);
+    await tick();
+
+    // Assert — the FCC re-rendered from its server attribute, not empty props.
+    const badge = window.document.body.querySelector(
+      "[data-fc='hydrate-badge']",
+    );
+    assert.equal(
+      badge?.querySelector("span")?.textContent,
+      "[Live]",
+      "hydrateRoot passed the server attribute to the FCC's update()",
+    );
+  });
+
+  it("start() gives each top-level unit its own payload entry across a nested unit", async (t) => {
+    // Arrange — the server builds the payload from a DESCENDING scan, so a nested
+    // unit's props sit between the two top-level units in document order.
+    const script = window.document.createElement("script");
+    script.type = "application/json";
+    script.id = "__hydration";
+    script.textContent = buildPayload([
+      { who: "A" }, // hydrate-panel (top-level)
+      { label: "nested" }, // hydrate-badge inside the panel
+      { label: "B" }, // hydrate-badge (top-level)
+    ]);
+    window.document.head.appendChild(script);
+
+    const container = window.document.createElement("div");
+    container.innerHTML =
+      `<hydrate-panel who="A"><div><div data-fc="hydrate-badge"><span>x</span></div></div></hydrate-panel>` +
+      `<div data-fc="hydrate-badge"><span>y</span></div>`;
+    window.document.body.append(container);
+    t.after(() => {
+      script.remove();
+      container.remove();
+    });
+
+    // Act
+    start(container);
+    await tick();
+
+    // Assert — the second top-level unit got payload[2] ("B"), not the nested
+    // unit's payload[1] ("nested").
+    const topBadge = container.children[1];
+    assert.equal(
+      topBadge.querySelector("span")?.textContent,
+      "[B]",
+      "top-level badge hydrated from its own payload entry across the nested unit",
     );
   });
 });

--- a/src/dom/hydrate.ts
+++ b/src/dom/hydrate.ts
@@ -1,6 +1,13 @@
 "use client"; // Hydrate runs entirely client side.
 
-import { reconcileChildren } from "./dom.ts";
+import {
+  isNested,
+  isUnit,
+  propsFromElement,
+  reconcileChildren,
+  scanAllUnits,
+} from "./dom.ts";
+import { attach, getFCC } from "./fc.ts";
 
 /**
  * Self-contained IIFE source for the capture stub. Embedded inline by the SSG
@@ -15,7 +22,7 @@ export const captureStubSource = `(function(){
     var unitEl = null;
     for (var i = 0; i < path.length; i++) {
       var node = path[i];
-      if (node instanceof Element && customElements.get(node.localName)) {
+      if (node instanceof Element && (customElements.get(node.localName) || node.getAttribute("data-fc"))) {
         unitEl = node;
         break;
       }
@@ -70,7 +77,7 @@ function scanUnits(root: ParentNode): Element[] {
   const stack: Element[] = [...root.children].reverse();
   while (stack.length > 0) {
     const el = stack.pop() as Element;
-    if (customElements.get(el.localName)) {
+    if (isUnit(el)) {
       results.push(el);
     } else {
       for (let i = el.children.length - 1; i >= 0; i--) {
@@ -82,33 +89,66 @@ function scanUnits(root: ParentNode): Element[] {
 }
 
 /**
- * Scan `root` for registered custom elements and schedule each for hydration.
- * `customElements.whenDefined` resolves as a microtask even when the element
- * is already defined. The callback clears server-rendered children then runs
- * `el.update()`, which re-executes the element's render function and rebuilds
- * its subtree. `root` defaults to `window.document.body`.
+ * Scan `root` for units and schedule each for hydration. `customElements.whenDefined`
+ * resolves as a microtask even when the element is already defined. The callback
+ * clears server-rendered children then runs `el.update()`, which re-executes the
+ * element's render function and rebuilds its subtree. `root` defaults to
+ * `window.document.body`.
+ *
+ * Units are enumerated with `scanAllUnits` — the SAME descending, document-order
+ * walk the server used to build the `#__hydration` payload — so `payload[index]`
+ * lines up with each unit even past nested ones. A nested unit is skipped here:
+ * its parent's re-render rebuilds it from fresh props, so a direct payload read
+ * would be redundant (and the enumeration only descends to keep indices aligned).
  */
 export function start(root?: ParentNode): void {
   const r = root ?? window.document.body;
-  const units = scanUnits(r);
+  const units = scanAllUnits(r);
   const payload = readPayload();
   units.forEach((el, index) => {
-    customElements.whenDefined(el.localName).then(() => {
-      el.replaceChildren();
-      el.update(payload[index]);
-      drainQueue(el);
-    });
+    if (isNested(el, units)) return;
+    // A data-fc boundary is never upgraded by the platform, so re-wire its
+    // behavior from the registry instead of waiting on customElements.
+    const fc = el.getAttribute("data-fc");
+    if (fc !== null) {
+      const update = getFCC(fc);
+      if (update) {
+        attach(el, update);
+        el.replaceChildren();
+        el.update(payload[index]);
+        drainQueue(el);
+      }
+    } else {
+      customElements.whenDefined(el.localName).then(() => {
+        el.replaceChildren();
+        el.update(payload[index]);
+        drainQueue(el);
+      });
+    }
   });
 }
 
-// Hydrate custom elements inside `root` without clearing their server-rendered
-// children first. `el.update()` reconciles onto the existing DOM so attributes
-// and listeners are grafted in place. Recurses after each element hydrates so
-// parents are always processed before their nested custom elements.
+// Hydrate units inside `root` without clearing their server-rendered children
+// first. `el.update(props)` reconciles onto the existing DOM so attributes and
+// listeners are grafted in place. Props are read back from the element's own
+// attributes (`propsFromElement`) — `hydrateRoot` reads no payload, and the
+// reconcile pass has already synced the fresh tree's attributes onto the kept
+// server node, so the attributes ARE the unit's props. Recurses after each
+// element hydrates so parents are always processed before their nested units.
 function startHydrate(root: ParentNode): void {
   for (const el of scanUnits(root)) {
+    const fc = el.getAttribute("data-fc");
+    if (fc !== null) {
+      const update = getFCC(fc);
+      if (update) {
+        attach(el, update);
+        el.update(propsFromElement(el));
+        startHydrate(el);
+      }
+      continue;
+    }
     customElements.whenDefined(el.localName).then(() => {
-      el.update();
+      el.update(propsFromElement(el));
       startHydrate(el);
     });
   }
@@ -139,7 +179,7 @@ export function installCaptureStub(): void {
     const path = event.composedPath() as Node[];
     let unitEl: Element | null = null;
     for (const node of path) {
-      if (node instanceof Element && customElements.get(node.localName)) {
+      if (node instanceof Element && isUnit(node)) {
         unitEl = node;
         break;
       }

--- a/src/ssg/ssg.ts
+++ b/src/ssg/ssg.ts
@@ -1,3 +1,4 @@
+import { isNested, propsFromElement, scanAllUnits } from "../dom/dom.ts";
 import { buildPayload, captureStubSource } from "../dom/hydrate.ts";
 import { renderToString } from "../dom/render.ts";
 import type { FileSystem } from "../fs.ts";
@@ -36,50 +37,6 @@ export interface BuildOptions {
   fs: FileSystem;
 }
 
-/**
- * Walk `root` depth-first and return every element whose localName is a
- * defined custom element, in document order including nested ones. Descends
- * into matched elements so the full set of custom elements is returned.
- */
-function scanAllUnits(root: ParentNode): Element[] {
-  const results: Element[] = [];
-  const stack: Element[] = [...root.children].reverse() as Element[];
-  while (stack.length > 0) {
-    const el = stack.pop() as Element;
-    if (customElements.get(el.localName)) {
-      results.push(el);
-    }
-    // Always descend — nested custom elements are included in the full set.
-    for (let i = el.children.length - 1; i >= 0; i--) {
-      stack.push(el.children[i] as Element);
-    }
-  }
-  return results;
-}
-
-/**
- * Return true if el has a custom-element ancestor in the given units list.
- */
-function isNested(el: Element, allUnits: Element[]): boolean {
-  let parent = el.parentElement;
-  while (parent !== null) {
-    if (allUnits.includes(parent)) return true;
-    parent = parent.parentElement;
-  }
-  return false;
-}
-
-/**
- * Extract a Record<string,unknown> from an element's attribute list.
- */
-function attrsToProps(el: Element): Record<string, unknown> {
-  const props: Record<string, unknown> = {};
-  for (const attr of el.attributes) {
-    props[attr.name] = attr.value;
-  }
-  return props;
-}
-
 export async function build({ pages, out, fs }: BuildOptions): Promise<void> {
   for (const { route, module } of pages) {
     const body = await module.default();
@@ -91,7 +48,7 @@ export async function build({ pages, out, fs }: BuildOptions): Promise<void> {
     const template = window.document.createElement("template");
     template.innerHTML = bodyStr;
     const allUnits = scanAllUnits(template.content);
-    const props = allUnits.map(attrsToProps);
+    const props = allUnits.map(propsFromElement);
 
     if (props.length > 0) {
       const payload = buildPayload(props);


### PR DESCRIPTION
FC builds every component as an HTML custom-element host, which is invalid in an SVG namespace. FCC creates a "componentless" functional component that does not use the customComponents API.

- FCC(name, boundary, render): the boundary factory builds the marked root in
  the right namespace; render returns the boundary's children (FC's contract).
- A shared isUnit(el) predicate generalizes the unit boundary from "registered
  custom element" to "custom element or data-fc", threaded through patchNode,
  scanUnits and the capture stub (hydrate), and scanAllUnits (ssg).
- A name->render registry backs the form where customElements backs FC;
  start()/startHydrate() re-wire data-fc boundaries from it on hydration.
- attrsToProps skips the data-fc marker so reconstructed props match author input.

Feature test (render + identity reuse across re-render) and a hydration test
both pass.

Co-Authored-By: "Ailly <developer@ailly.dev>"
