### PR TITLE
Type-safe data-*/aria-*/for/role attributes (closes #42)

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -35,19 +35,115 @@ export type DenormChildren =
 
 export type DOMElement = Element & ElementCSSInlineStyle;
 
+// WAI-ARIA 1.2 role tokens. The DOM lib does not ship an `AriaRole` type (it is
+// a React-only export), so the constrained set is named here.
+export type AriaRole =
+  | "alert"
+  | "alertdialog"
+  | "application"
+  | "article"
+  | "banner"
+  | "button"
+  | "cell"
+  | "checkbox"
+  | "columnheader"
+  | "combobox"
+  | "complementary"
+  | "contentinfo"
+  | "definition"
+  | "dialog"
+  | "directory"
+  | "document"
+  | "feed"
+  | "figure"
+  | "form"
+  | "grid"
+  | "gridcell"
+  | "group"
+  | "heading"
+  | "img"
+  | "link"
+  | "list"
+  | "listbox"
+  | "listitem"
+  | "log"
+  | "main"
+  | "marquee"
+  | "math"
+  | "menu"
+  | "menubar"
+  | "menuitem"
+  | "menuitemcheckbox"
+  | "menuitemradio"
+  | "navigation"
+  | "none"
+  | "note"
+  | "option"
+  | "presentation"
+  | "progressbar"
+  | "radio"
+  | "radiogroup"
+  | "region"
+  | "row"
+  | "rowgroup"
+  | "rowheader"
+  | "scrollbar"
+  | "search"
+  | "searchbox"
+  | "separator"
+  | "slider"
+  | "spinbutton"
+  | "status"
+  | "switch"
+  | "tab"
+  | "table"
+  | "tablist"
+  | "tabpanel"
+  | "term"
+  | "textbox"
+  | "timer"
+  | "toolbar"
+  | "tooltip"
+  | "tree"
+  | "treegrid"
+  | "treeitem";
+
 export type DomAttrs = {
   class: string | string[];
   style: Partial<SVGProperties> | string;
-  role: "button" | "list" | "listbox";
+  role: AriaRole;
   events: Partial<{
     [K in keyof HTMLElementEventMap]: EventHandler | null;
   }>;
 };
 
+/**
+ * Universal attributes valid on any HTML/SVG element that are NOT named on an
+ * element's own DOM-property type (or whose attribute name differs from the
+ * property name): the open-ended `data-*`/`aria-*` families, plus `for` (the
+ * label association attribute — the DOM property is `htmlFor`). Folded into
+ * every `Attrs` so the common case needs no supplemental `S` and no cast; the
+ * engine writes each key verbatim with `setAttribute`.
+ */
+export type GlobalAttrs = {
+  [key: `data-${string}`]: string | number | boolean;
+  [key: `aria-${string}`]: string | number | boolean;
+  for: string;
+};
+
+/**
+ * Attributes accepted by a builder / `up()` for element `E`. The element's own
+ * string/number/boolean DOM properties, the framework `DomAttrs`
+ * (class/style/role/events), the `GlobalAttrs` aliases, and the optional
+ * supplemental set `S` — the constrained widening hook a caller (or a typed
+ * builder like the SVG ones) uses to name extra verbatim attributes (e.g. SVG
+ * presentation attrs) without casting the whole payload.
+ */
 export type Attrs<E extends Omit<Element, "update">, S = object> = Partial<
   Omit<{ [k in keyof E]: string | number | boolean }, "style" | "toString"> &
     S &
-    DomAttrs
+    DomAttrs &
+    GlobalAttrs
 >;
 
 export type DenormAttrs<E extends Omit<Element, "update">, S = object> =
@@ -97,12 +193,15 @@ export function normalizeArguments<E extends Element>(
   return [attributes, children.flat().filter((c) => c != null && c !== false)];
 }
 
-export function up<E extends Element>(
+export function up<E extends Element, S = object>(
   element: Omit<E, "update">,
-  attrs?: DenormAttrs<E>,
+  attrs?: DenormAttrs<E, S>,
   ...children: DenormChildren[]
 ): E {
-  return update(element, ...normalizeArguments(attrs, children)) as E;
+  return update(
+    element,
+    ...normalizeArguments(attrs as DenormAttrs<E>, children),
+  ) as E;
 }
 
 /**

--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -35,8 +35,7 @@ export type DenormChildren =
 
 export type DOMElement = Element & ElementCSSInlineStyle;
 
-// WAI-ARIA 1.2 role tokens. The DOM lib does not ship an `AriaRole` type (it is
-// a React-only export), so the constrained set is named here.
+// WAI-ARIA 1.2 role tokens. The DOM lib does not ship an `AriaRole` type.
 export type AriaRole =
   | "alert"
   | "alertdialog"
@@ -118,12 +117,9 @@ export type DomAttrs = {
 };
 
 /**
- * Universal attributes valid on any HTML/SVG element that are NOT named on an
- * element's own DOM-property type (or whose attribute name differs from the
- * property name): the open-ended `data-*`/`aria-*` families, plus `for` (the
- * label association attribute — the DOM property is `htmlFor`). Folded into
- * every `Attrs` so the common case needs no supplemental `S` and no cast; the
- * engine writes each key verbatim with `setAttribute`.
+ * Jiffies intrinsic DataSet attributes.
+ * 
+ * DOM types don't include data- and aria- properties, they come from JSX intrinsics.
  */
 export type GlobalAttrs = {
   [key: `data-${string}`]: string | number | boolean;
@@ -135,9 +131,7 @@ export type GlobalAttrs = {
  * Attributes accepted by a builder / `up()` for element `E`. The element's own
  * string/number/boolean DOM properties, the framework `DomAttrs`
  * (class/style/role/events), the `GlobalAttrs` aliases, and the optional
- * supplemental set `S` — the constrained widening hook a caller (or a typed
- * builder like the SVG ones) uses to name extra verbatim attributes (e.g. SVG
- * presentation attrs) without casting the whole payload.
+ * supplemental set `S`.
  */
 export type Attrs<E extends Omit<Element, "update">, S = object> = Partial<
   Omit<{ [k in keyof E]: string | number | boolean }, "style" | "toString"> &

--- a/src/dom/form/form.ts
+++ b/src/dom/form/form.ts
@@ -28,13 +28,7 @@ export const Form = (attrs: FormAttributes, ...children: DenormChildren[]) => {
   return form(attrs as Attrs<HTMLFormElement>, ...children);
 };
 export const Input = (attrs: InputAttributes, ...children: DenormChildren[]) =>
-  label(
-    input(
-      // @ts-expect-error
-      attrs as Attrs<HTMLInputElement>,
-    ),
-    ...children,
-  );
+  label(input(attrs as Attrs<HTMLInputElement>), ...children);
 
 export const Select = (
   attrs: { options: string[] | object; selected?: string } & SelectAttributes &

--- a/src/dom/html.test.ts
+++ b/src/dom/html.test.ts
@@ -1,6 +1,18 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { button, table, tbody, td, th, thead, tr } from "./html.ts";
+import type { GlobalAttrs } from "./dom.ts";
+import {
+  button,
+  div,
+  input,
+  label,
+  table,
+  tbody,
+  td,
+  th,
+  thead,
+  tr,
+} from "./html.ts";
 
 describe("html", () => {
   it("creates HTML Elements", () => {
@@ -82,5 +94,39 @@ describe("html", () => {
     assert.ok(btn.classList.contains("test-class"));
     assert.strictEqual(btn.style.flexDirection, "column");
     assert.ok(clicked);
+  });
+
+  it("accepts the GlobalAttrs aliases (data-*, aria-*, for, role) with no cast", () => {
+    // Before the supplemental-attrs typing, none of these keys were named on the
+    // element's own property type, so each call needed a `as` cast to widen the
+    // literal. They are now in every builder's accepted attrs and written
+    // verbatim.
+    const lbl = label({ for: "email" }, "Email");
+    const group = div({ role: "group", "data-value": "galilean" });
+    const field = input({
+      type: "checkbox",
+      "data-var": "--ground",
+      "aria-label": "Background",
+    });
+
+    assert.strictEqual(lbl.getAttribute("for"), "email");
+    assert.strictEqual(group.getAttribute("role"), "group");
+    assert.strictEqual(group.getAttribute("data-value"), "galilean");
+    assert.strictEqual(field.getAttribute("data-var"), "--ground");
+    assert.strictEqual(field.getAttribute("aria-label"), "Background");
+  });
+
+  it("accepts a supplemental attrs type parameter S for extra verbatim keys", () => {
+    // The `S` hook names extra attributes inline without widening every key. Here
+    // a caller declares a bespoke `data-custom` payload via S; the engine writes
+    // it like any other attribute.
+    const el = div<{ "data-custom": string }>({ "data-custom": "x" });
+    assert.strictEqual(el.getAttribute("data-custom"), "x");
+
+    // GlobalAttrs is exported so callers can name the alias set explicitly.
+    const typed: GlobalAttrs = { "data-value": "1", for: "y" };
+    const reuse = div(typed);
+    assert.strictEqual(reuse.getAttribute("data-value"), "1");
+    assert.strictEqual(reuse.getAttribute("for"), "y");
   });
 });

--- a/src/dom/html.ts
+++ b/src/dom/html.ts
@@ -2,13 +2,13 @@ import { type DenormAttrs, type DenormChildren, up } from "./dom.ts";
 
 const makeHTMLElement =
   <K extends keyof HTMLElementTagNameMap>(name: K) =>
-  (
-    attrs?: DenormAttrs<HTMLElementTagNameMap[K]>,
+  <S = object>(
+    attrs?: DenormAttrs<HTMLElementTagNameMap[K], S>,
     ...children: DenormChildren[]
   ) =>
     up(
       window.document.createElement(name),
-      attrs,
+      attrs as DenormAttrs<HTMLElementTagNameMap[K]>,
       ...children,
     ) as HTMLElementTagNameMap[K];
 

--- a/src/dom/hydrate.ts
+++ b/src/dom/hydrate.ts
@@ -1,6 +1,7 @@
 "use client"; // Hydrate runs entirely client side.
 
 import {
+  type DenormAttrs,
   isNested,
   isUnit,
   propsFromElement,
@@ -115,13 +116,13 @@ export function start(root?: ParentNode): void {
       if (update) {
         attach(el, update);
         el.replaceChildren();
-        el.update(payload[index]);
+        el.update(payload[index] as DenormAttrs<Element>);
         drainQueue(el);
       }
     } else {
       customElements.whenDefined(el.localName).then(() => {
         el.replaceChildren();
-        el.update(payload[index]);
+        el.update(payload[index] as DenormAttrs<Element>);
         drainQueue(el);
       });
     }
@@ -142,13 +143,13 @@ function startHydrate(root: ParentNode): void {
       const update = getFCC(fc);
       if (update) {
         attach(el, update);
-        el.update(propsFromElement(el));
+        el.update(propsFromElement(el) as DenormAttrs<Element>);
         startHydrate(el);
       }
       continue;
     }
     customElements.whenDefined(el.localName).then(() => {
-      el.update(propsFromElement(el));
+      el.update(propsFromElement(el) as DenormAttrs<Element>);
       startHydrate(el);
     });
   }


### PR DESCRIPTION
Closes #42.

## What

Threads the supplemental-attrs typing through the HTML path so `data-*`, `aria-*`, `for`, and ARIA roles typecheck without a cast.

- **`GlobalAttrs`** (`data-${string}` / `aria-${string}` / `for`) folded into `Attrs<E, S>` — the common case needs no cast and no `S`.
- **`AriaRole`** (WAI-ARIA 1.2 set; the DOM lib ships none) widens `DomAttrs.role` so `role="group"` etc. are accepted.
- **`S` threaded through `up<E, S>()` and the HTML builders** (the SVG builders already did this), so callers can name extra verbatim keys inline: `div<{ "data-custom": string }>({ ... })`.

## Why

Builders/`up()` previously only accepted keys named on the element's own DOM-property type, so the three families above were rejected even though `update()` writes them verbatim at runtime. Consumers cast the whole literal (`a<T>(attrs)`, `setAttrs`), erasing all attribute typing and hiding typos.

## Compatibility

Purely additive at the type level; runtime unchanged. One consequence: an untyped `Record<string, unknown>` bag is no longer assignable to `Attrs` (its `string`/`unknown` index conflicts with the new `data-*` index). The few internal sites passing dynamic prop bags (`hydrate.ts` `propsFromElement`/payload) cast at the boundary.

## Tests

`npm test` green (204 passing). Adds `html.test.ts` coverage for the alias set and the `S` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)